### PR TITLE
Add mjpeg streamer environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ COPY haproxy.cfg /etc/haproxy/haproxy.cfg
 COPY supervisord.conf /etc/supervisor/supervisord.conf
 
 ENV CAMERA_DEV /dev/video0
-ENV STREAMER_FLAGS -y -n
+ENV STREAMER_FLAGS -y -n -r 640x480
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ COPY haproxy.cfg /etc/haproxy/haproxy.cfg
 COPY supervisord.conf /etc/supervisor/supervisord.conf
 
 ENV CAMERA_DEV /dev/video0
+ENV MJPEG_STREAMER_AUTOSTART true
 ENV STREAMER_FLAGS -y -n -r 640x480
 
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ $ docker run \
   nunofgs/octoprint
 ```
 
+# Environment Variables
+
+| Variable                 | Description                    | Default Value      |
+| ------------------------ | ------------------------------ | ------------------ |
+| CAMERA_DEV               | The camera device node         | `/dev/video0`      |
+| STREAMER_FLAGS           | Flags to pass to mjpg_streamer | `-y -n -r 640x480` |
+
 # CuraEngine integration
 
 Cura engine integration was very outdated (using version `15.04.6`) and was removed.
@@ -34,7 +41,7 @@ It will return once OctoPrint [supports python3](https://github.com/foosel/OctoP
 # Webcam integration
 
 1. Bind the camera to the docker using --device=/dev/video0:/dev/videoX
-2. If camera supports only MJPEG formatting, please set STREAMER_FLAGS to "" or something else.
+2. Optionally, change `STREAMER_FLAGS` to your preferred settings (ex: `-y -n -r 1280x720 -f 10`)
 3. Use the following settings in octoprint:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ $ docker run \
 | Variable                 | Description                    | Default Value      |
 | ------------------------ | ------------------------------ | ------------------ |
 | CAMERA_DEV               | The camera device node         | `/dev/video0`      |
+| MJPEG_STREAMER_AUTOSTART | Start the camera automatically | `true`             |
 | STREAMER_FLAGS           | Flags to pass to mjpg_streamer | `-y -n -r 640x480` |
 
 # CuraEngine integration

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -17,7 +17,7 @@ stdout_logfile_maxbytes=0
 
 [program:mjpeg-streamer]
 autostart=false
-command=mjpg_streamer -i "/usr/local/lib/mjpg-streamer/input_uvc.so %(ENV_STREAMER_FLAGS)s -r 640x480 -d %(ENV_CAMERA_DEV)s" -o "/usr/local/lib/mjpg-streamer/output_http.so -w /usr/local/www -p 8080"
+command=mjpg_streamer -i "/usr/local/lib/mjpg-streamer/input_uvc.so %(ENV_STREAMER_FLAGS)s -d %(ENV_CAMERA_DEV)s" -o "/usr/local/lib/mjpg-streamer/output_http.so -w /usr/local/www -p 8080"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -16,7 +16,7 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
 [program:mjpeg-streamer]
-autostart=false
+autostart=%(ENV_MJPEG_STREAMER_AUTOSTART)s
 command=mjpg_streamer -i "/usr/local/lib/mjpg-streamer/input_uvc.so %(ENV_STREAMER_FLAGS)s -d %(ENV_CAMERA_DEV)s" -o "/usr/local/lib/mjpg-streamer/output_http.so -w /usr/local/www -p 8080"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
Adds an environment variable to autostart mjpeg_streamer (and changes the default to `true`), and moves the default resolution to the `STREAMER_FLAGS` environment variable.

Closes #6