### PR TITLE
Install plugins in `/data/plugins` by default

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
 !Dockerfile
 !haproxy.cfg
+!pip.conf
 !supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ VOLUME /data
 WORKDIR /data
 
 COPY haproxy.cfg /etc/haproxy/haproxy.cfg
+COPY pip.conf /root/.pip/pip.conf
 COPY supervisord.conf /etc/supervisor/supervisord.conf
 
 ENV CAMERA_DEV /dev/video0

--- a/pip.conf
+++ b/pip.conf
@@ -1,0 +1,2 @@
+[install]
+install-option=--install-purelib=/data/plugins


### PR DESCRIPTION
Adds a pip configuration file that tells `pip` to always install plugins to `/data/plugins`. Since octoprint already has support for loading plugins from there, the result is that plugins are now saved in your data directory!

Fixes #5