### PR TITLE
Fix path to mjpg-streamer www folder

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -17,7 +17,7 @@ stdout_logfile_maxbytes=0
 
 [program:mjpeg-streamer]
 autostart=%(ENV_MJPEG_STREAMER_AUTOSTART)s
-command=mjpg_streamer -i "/usr/local/lib/mjpg-streamer/input_uvc.so %(ENV_STREAMER_FLAGS)s -d %(ENV_CAMERA_DEV)s" -o "/usr/local/lib/mjpg-streamer/output_http.so -w /usr/local/www -p 8080"
+command=mjpg_streamer -i "/usr/local/lib/mjpg-streamer/input_uvc.so %(ENV_STREAMER_FLAGS)s -d %(ENV_CAMERA_DEV)s" -o "/usr/local/lib/mjpg-streamer/output_http.so -w /usr/local/share/mjpg-streamer/www -p 8080"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 


### PR DESCRIPTION
Fixes the path to mjpg-streamer's `www` folder to enable access to the control page (`control.htm`)

`/webcam/control.htm`
![image](https://user-images.githubusercontent.com/721505/52916842-fd2da680-32a9-11e9-9549-01760ab0e2cb.png)
