### PR TITLE
Replace libav with ffmpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   avrdude \
   build-essential \
   cmake \
+  ffmpeg \
   git \
   haproxy \
   imagemagick \
-  libav-tools \
   v4l-utils \
   libjpeg-dev \
   libjpeg62-turbo \


### PR DESCRIPTION
The python base image I'm using has tagged `2.7-*` with debian `buster` thus deprecating `stretch` and, with it, `libav-tools`.