### PR TITLE
Add support for armv6, arm64 using buildx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 before_install:
-  - sudo apt-get install docker-ce=18.02.0~ce-0~ubuntu
-  - mkdir ~/.docker && echo '{ "experimental":"enabled" }' > ~/.docker/config.json
+  - curl -sf https://test.docker.com | sh
   - docker --version
+
+dist: bionic
 
 language: bash
 
 env:
+  global:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - PLATFORMS=linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
   matrix:
-    - ARCH=amd64
-    - ARCH=arm32v7
+    - VARIANT=alpine
+    - VARIANT=debian
 
 stages:
   - name: test
@@ -17,30 +21,16 @@ stages:
     if: tag IS present OR branch = master
 
 script:
-  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
-  - docker build -t "nunofgs/octoprint:$TRAVIS_BRANCH-$ARCH" --build-arg "arch=$ARCH" --build-arg "version=$TRAVIS_BRANCH" .
-  - docker login -u=nunofgs -p="$DOCKER_PASSWORD"
-  - docker push "nunofgs/octoprint:$TRAVIS_BRANCH-$ARCH"
-
-jobs:
-  include:
-    - stage: push
-      script:
-        - docker login -u=nunofgs -p="$DOCKER_PASSWORD"
-        - docker pull "nunofgs/octoprint:$TRAVIS_BRANCH-amd64"
-        - docker pull "nunofgs/octoprint:$TRAVIS_BRANCH-arm32v7"
-        - >
-          docker manifest create "nunofgs/octoprint:$TRAVIS_BRANCH" "nunofgs/octoprint:$TRAVIS_BRANCH-amd64" "nunofgs/octoprint:$TRAVIS_BRANCH-arm32v7" &&
-          docker manifest annotate "nunofgs/octoprint:$TRAVIS_BRANCH" "nunofgs/octoprint:$TRAVIS_BRANCH-arm32v7" --os linux --arch arm --variant v6 &&
-          docker manifest push "nunofgs/octoprint:$TRAVIS_BRANCH"
-        - >
-          if [ -n "$TRAVIS_TAG" ]; then
-            docker tag "nunofgs/octoprint:$TRAVIS_BRANCH-amd64" nunofgs/octoprint:latest &&
-            docker push nunofgs/octoprint:latest
-          fi
-        - >
-          if [ -n "$TRAVIS_TAG" ]; then
-            docker manifest create "nunofgs/octoprint:latest" "nunofgs/octoprint:$TRAVIS_BRANCH-amd64" "nunofgs/octoprint:$TRAVIS_BRANCH-arm32v7" &&
-            docker manifest annotate "nunofgs/octoprint:latest" "nunofgs/octoprint:$TRAVIS_BRANCH-arm32v7" --os linux --arch arm --variant v6 &&
-            docker manifest push "nunofgs/octoprint:latest"
-          fi
+  - echo "$DOCKER_PASSWORD" | docker login -u nunofgs --password-stdin
+  - docker run --privileged linuxkit/binfmt:v0.7
+  - docker buildx create --use
+  - docker buildx build
+    --platform $PLATFORMS
+    --build-arg "version=$TRAVIS_BRANCH"
+    --file "$VARIANT/Dockerfile"
+    --tag nunofgs/octoprint:$TRAVIS_BRANCH-$VARIANT
+    `if [ -n "$TRAVIS_TAG" ]; then echo "--tag nunofgs/octoprint:$VARIANT"; fi`
+    `if [ -n "$TRAVIS_TAG" ] && [ "$VARIANT" = "debian" ]; then echo "--tag nunofgs/octoprint:latest"; fi`
+    `if [ "$VARIANT" = "debian" ]; then echo "--tag nunofgs/octoprint:$TRAVIS_BRANCH"; fi`
+    --push
+    .

--- a/README.md
+++ b/README.md
@@ -5,25 +5,39 @@
 This is a Dockerfile to set up [OctoPrint](http://octoprint.org/). It supports the following architectures automatically:
 
 - x86
-- arm32v6 (Raspberry Pi, etc.)
+- arm32v6 [<sup>1</sup>](#armv6-docker-bug)
+- arm32v7
+- arm64
+
+Just run:
+
+```sh
+docker run nunofgs/octoprint
+```
+
+Now have a beer, you did it. 🍻
 
 # Tags
 
-- `1.3.11`, `latest` ([Dockerfile](https://github.com/nunofgs/docker-octoprint/blob/master/Dockerfile))
-- `1.3.10` ([Dockerfile](https://github.com/nunofgs/docker-octoprint/blob/master/Dockerfile))
-- `1.3.9` ([Dockerfile](https://github.com/nunofgs/docker-octoprint/blob/master/Dockerfile))
-- `1.3.8` ([Dockerfile](https://github.com/nunofgs/docker-octoprint/blob/master/Dockerfile))
-- `1.3.7` ([Dockerfile](https://github.com/nunofgs/docker-octoprint/blob/master/Dockerfile))
-- `1.3.6` ([Dockerfile](https://github.com/nunofgs/docker-octoprint/blob/master/Dockerfile))
-- `master` (_Automatically built daily from OctoPrint's `master` branch_)
+- `1.3.11`, `1.3.11-debian`, `debian`, `latest-debian`, `latest` ([Dockerfile](https://github.com/nunofgs/docker-octoprint/blob/master/debian/Dockerfile))
+- `1.3.11-alpine`, `alpine`, `latest-alpine` ([Dockerfile](https://github.com/nunofgs/docker-octoprint/blob/master/alpine/Dockerfile))
+- `1.3.10` ([Dockerfile](https://github.com/nunofgs/docker-octoprint/blob/master/debian/Dockerfile))
+- `1.3.9` ([Dockerfile](https://github.com/nunofgs/docker-octoprint/blob/master/debian/Dockerfile))
+- `1.3.8` ([Dockerfile](https://github.com/nunofgs/docker-octoprint/blob/master/debian/Dockerfile))
+- `1.3.7` ([Dockerfile](https://github.com/nunofgs/docker-octoprint/blob/master/debian/Dockerfile))
+- `1.3.6` ([Dockerfile](https://github.com/nunofgs/docker-octoprint/blob/master/debian/Dockerfile))
+- `master-debian`, `master` (_Automatically built daily from OctoPrint's `master` branch_)
+- `master-alpine` (_Automatically built daily from OctoPrint's `master` branch_)
 
 # Tested devices
 
 | Device              | Working? |
 | ------------------- | -------- |
-| Raspberry Pi 2b     | ✅        |
-| Raspberry Pi 3b+    | ✅        |
-| Raspberry Pi Zero W | ❌        |
+| Raspberry Pi 2b     | ✅       |
+| Raspberry Pi 3b+    | ✅       |
+| Raspberry Pi Zero W | ✅       |
+
+Please let me know if you test any others, would love to increase the compatibility list!
 
 # Usage
 
@@ -63,6 +77,33 @@ webcam:
 ```
 
 # Notes
+
+## Distro variants
+
+There are currently _alpine_ and _debian_ variants available of this image. At time of writing, here are their sizes:
+
+| Variant         | Size      |
+|-----------------|---------- |
+| _1.3.11-alpine_ | **474MB** |
+| _1.3.11-debian_ | **889MB** |
+
+While SD cards are pretty cheap these days, a smaller image is always preferrable so feel free to submit PRs that reduce the image size without affecting functionality!
+
+## ARMv6 Docker Bug
+
+_ARM32v6_ devices such as the Raspberry Pi Zero (W) are unfortunately unable to pull this image directly using `docker pull nunofgs/octoprint` due to a bug in Docker ([moby/moby#37647](https://github.com/moby/moby/issues/37647), [moby/moby#34875](https://github.com/moby/moby/issues/34875)). There's a [PR open](https://github.com/moby/moby/pull/36121#issuecomment-515243647) to fix this but it might be some time until it hits a stable Docker release.
+
+Until then, you can run this container by specifying the armv6 image hash. Example on [HypriotOS 1.11.0](https://blog.hypriot.com):
+
+```sh
+$ docker manifest inspect nunofgs/octoprint | grep -e "variant.*v6" -B 4
+
+# copy sha256 hash of the v6 image you want to run.
+
+$ docker run nunofgs/octoprint@sha256:dce9b67ccd25bb63c3024ab96c55428281d8c3955c95c7b5133807133863da29
+```
+
+## Toggle the camera on/off
 
 This image uses `supervisord` in order to launch 3 processes: _haproxy_, _octoprint_ and _mjpeg-streamer_.
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,52 @@
+ARG arch
+
+# Intermediate build container.
+FROM python:2.7-alpine3.10 as build
+
+ARG version
+
+RUN apk --no-cache add build-base
+RUN apk --no-cache add cmake
+RUN apk --no-cache add libjpeg-turbo-dev
+RUN apk --no-cache add linux-headers
+RUN apk --no-cache add openssl
+
+# Download packages
+RUN wget -qO- https://github.com/foosel/OctoPrint/archive/${version}.tar.gz | tar xz
+RUN wget -qO- https://github.com/jacksonliam/mjpg-streamer/archive/master.tar.gz | tar xz
+
+# Install mjpg-streamer
+WORKDIR /mjpg-streamer-master/mjpg-streamer-experimental
+RUN make
+RUN make install
+
+# Install OctoPrint
+WORKDIR /OctoPrint-${version}
+RUN pip install -r requirements.txt
+RUN python setup.py install
+
+FROM python:2.7-alpine3.10
+
+COPY --from=build /usr/local/bin /usr/local/bin
+COPY --from=build /usr/local/lib /usr/local/lib
+COPY --from=build /mjpg-streamer-*/mjpg-streamer-experimental /opt/mjpg-streamer
+COPY --from=build /OctoPrint-* /opt/octoprint
+
+RUN apk --no-cache add build-base ffmpeg haproxy libjpeg openssh-client v4l-utils && \
+  pip install supervisor
+
+VOLUME /data
+WORKDIR /data
+
+COPY haproxy.cfg /etc/haproxy/haproxy.cfg
+COPY supervisord.conf /etc/supervisor/supervisord.conf
+
+ENV CAMERA_DEV /dev/video0
+ENV MJPEG_STREAMER_AUTOSTART true
+ENV PIP_USER true
+ENV PYTHONUSERBASE /data/plugins
+ENV STREAMER_FLAGS -y -n -r 640x480
+
+EXPOSE 80
+
+CMD ["/usr/local/bin/python", "/usr/local/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,10 +1,7 @@
 ARG arch
 
-# Intermediate build container with arm support.
-FROM hypriot/qemu-register as qemu
-FROM $arch/python:2.7-slim as build
-
-COPY --from=qemu /qemu-arm /usr/bin/qemu-arm-static
+# Intermediate build container.
+FROM python:2.7-slim as build
 
 ARG version
 


### PR DESCRIPTION
Big PR, bear with me:

* Added armv6 support again (fixes #29) by switching to _buildx_ for multi-arch building
* Added an `alpine` variant which was removed some time ago due to the inability to build armv7 images at the time
* Removes all qemu-explicit registers in favor of _buildx_ (yay)
* Updated the README.md