### PR TITLE
Remove libraspberrypi-dev dependency from arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
   - docker buildx create --use
   - docker buildx build
     --platform $PLATFORMS
-    --build-arg "version=$TRAVIS_BRANCH"
+    --build-arg "VERSION=$TRAVIS_BRANCH"
     --file "$VARIANT/Dockerfile"
     --tag nunofgs/octoprint:$TRAVIS_BRANCH-$VARIANT
     `if [ -n "$TRAVIS_TAG" ]; then echo "--tag nunofgs/octoprint:$VARIANT"; fi`

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,17 +1,18 @@
 # Intermediate build container.
 FROM python:2.7-alpine3.10 as build
 
-ARG version
+ARG TARGETPLATFORM
+ARG VERSION
 
 RUN apk --no-cache add build-base
 RUN apk --no-cache add cmake
 RUN apk --no-cache add libjpeg-turbo-dev
 RUN apk --no-cache add linux-headers
 RUN apk --no-cache add openssl
-RUN apk --no-cache add raspberrypi-dev || true
+RUN [[ "${TARGETPLATFORM:6}" != "arm64" ]] && apk --no-cache add raspberrypi-dev || true
 
 # Download packages
-RUN wget -qO- https://github.com/foosel/OctoPrint/archive/${version}.tar.gz | tar xz
+RUN wget -qO- https://github.com/foosel/OctoPrint/archive/${VERSION}.tar.gz | tar xz
 RUN wget -qO- https://github.com/jacksonliam/mjpg-streamer/archive/master.tar.gz | tar xz
 
 # Install mjpg-streamer
@@ -20,7 +21,7 @@ RUN make
 RUN make install
 
 # Install OctoPrint
-WORKDIR /OctoPrint-${version}
+WORKDIR /OctoPrint-${VERSION}
 RUN pip install -r requirements.txt
 RUN python setup.py install
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:2.7-slim
 
-ARG version
+ARG TARGETPLATFORM
+ARG VERSION
 
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -24,10 +25,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget \
   zlib1g-dev
 
-RUN apt-get install -y libraspberrypi-dev || true
+RUN [[ "${TARGETPLATFORM:6}" != "arm64" ]] && apt-get install -y libraspberrypi-dev || true
 
 # Download packages
-RUN wget -qO- https://github.com/foosel/OctoPrint/archive/${version}.tar.gz | tar xz
+RUN wget -qO- https://github.com/foosel/OctoPrint/archive/${VERSION}.tar.gz | tar xz
 RUN wget -qO- https://github.com/jacksonliam/mjpg-streamer/archive/master.tar.gz | tar xz
 
 # Install mjpg-streamer
@@ -36,7 +37,7 @@ RUN make
 RUN make install
 
 # Install OctoPrint
-WORKDIR /OctoPrint-${version}
+WORKDIR /OctoPrint-${VERSION}
 RUN pip install -r requirements.txt
 RUN python setup.py install
 


### PR DESCRIPTION
Unfortunately `libraspberrypi-dev` doesn't compile on ARM64, so this PR removes support for the raspberry pi camera module on ARM64. The good news is that there isn't really any raspberry pis that run on ARM64 so nobody should be affected by this.

Bug is reported on: https://github.com/raspberrypi/userland/issues/314