### PR TITLE
Add OctoLapse support

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -6,11 +6,11 @@ ARG VERSION
 
 RUN apk --no-cache add build-base
 RUN apk --no-cache add cmake
+RUN apk --no-cache add gphoto2
 RUN apk --no-cache add libjpeg-turbo-dev
 RUN apk --no-cache add linux-headers
 RUN apk --no-cache add openssl
 RUN apk --no-cache add zlib
-RUN apk --no-cache add gphoto2
 RUN [[ "${TARGETPLATFORM:6}" != "arm64" ]] && apk --no-cache add raspberrypi-dev || true
 
 # Download packages

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -10,6 +10,7 @@ RUN apk --no-cache add libjpeg-turbo-dev
 RUN apk --no-cache add linux-headers
 RUN apk --no-cache add openssl
 RUN apk --no-cache add zlib
+RUN apk --no-cache add gphoto2
 RUN [[ "${TARGETPLATFORM:6}" != "arm64" ]] && apk --no-cache add raspberrypi-dev || true
 
 # Download packages

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -9,6 +9,7 @@ RUN apk --no-cache add cmake
 RUN apk --no-cache add libjpeg-turbo-dev
 RUN apk --no-cache add linux-headers
 RUN apk --no-cache add openssl
+RUN apk --no-cache add zlib
 RUN [[ "${TARGETPLATFORM:6}" != "arm64" ]] && apk --no-cache add raspberrypi-dev || true
 
 # Download packages
@@ -22,8 +23,8 @@ RUN make install
 
 # Install OctoPrint
 WORKDIR /OctoPrint-${VERSION}
-RUN pip install -r requirements.txt
-RUN python setup.py install
+RUN LIBRARY_PATH=/lib:/usr/lib pip install -r requirements.txt
+RUN LIBRARY_PATH=/lib:/usr/lib python setup.py install
 
 # Build final image
 FROM python:2.7-alpine3.10

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ffmpeg \
   fontconfig \
   git \
+  gphoto2 \
   haproxy \
   imagemagick \
   v4l-utils \
@@ -25,6 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   supervisor \
   unzip \
   wget \
+  zlib \
   zlib1g-dev
 
 RUN [[ "${TARGETPLATFORM:6}" != "arm64" ]] && apt-get install -y libraspberrypi-dev || true


### PR DESCRIPTION
OctoLapse requires `zlib` to be installed, and many people will want to use it with `gphoto2` as well.