### PR TITLE
Basedir as a subdir in the docker volume, allows backup plugin restor…

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -33,7 +33,7 @@ COPY --from=build /usr/local/lib /usr/local/lib
 COPY --from=build /mjpg-streamer-*/mjpg-streamer-experimental /opt/mjpg-streamer
 COPY --from=build /OctoPrint-* /opt/octoprint
 
-RUN apk --no-cache add build-base ffmpeg haproxy libjpeg openssh-client supervisor v4l-utils
+RUN apk --no-cache add build-base ffmpeg haproxy libjpeg openssh-client supervisor v4l-utils python-dev py-pip jpeg-dev zlib-dev
 RUN ln -s ~/.octoprint /data
 
 VOLUME /data
@@ -48,6 +48,7 @@ ENV MJPEG_STREAMER_AUTOSTART true
 ENV MJPEG_STREAMER_INPUT -y -n -r 640x480
 ENV PIP_USER true
 ENV PYTHONUSERBASE /data/plugins
+ENV LIBRARY_PATH=/lib:/usr/lib
 
 EXPOSE 80
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -60,3 +60,5 @@ ENV PYTHONUSERBASE /data/plugins
 EXPOSE 80
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]
+
+HEALTHCHECK --start-period=30s CMD wget --quiet --tries=1 --spider http://localhost:80/

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -26,7 +26,7 @@ stdout_logfile_maxbytes=0
 stdout_logfile=/dev/stdout
 
 [program:octoprint]
-command=octoprint serve --iknowwhatimdoing --host 0.0.0.0
+command=octoprint serve --iknowwhatimdoing --host 0.0.0.0 --basedir /data/octoprint
 stderr_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
The backup plugin wants to move the base dir to a backup location as a final step:
https://github.com/foosel/OctoPrint/blob/master/src/octoprint/plugins/backup/__init__.py#L858

This fails with default basedir `/root/.octoprint` linked to `/data`.

Moved the basedir inside the `/data` volume which seems to fix the issue.

Added healtcheck to debian but have not tested it very well.